### PR TITLE
Remove extraneous args for Declare/InstallGlobalFunction

### DIFF
--- a/lib/cyclic-torus-covers.gd
+++ b/lib/cyclic-torus-covers.gd
@@ -64,12 +64,12 @@ DeclareGlobalFunction("CombOrigami");
 #! gap> SearchForCyclicTorusOrigamiWithVeechGroup(4, 3, H);
 #! [ 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1 ]
 #! @EndExampleSession
-DeclareGlobalFunction("SearchForCyclicTorusOrigamiWithVeechGroup", [IsPosInt, IsPosInt, IsMatrixGroup]);
+DeclareGlobalFunction("SearchForCyclicTorusOrigamiWithVeechGroup");
 
 #! @BeginGroup
 #! @GroupTitle Cyclic torus cover origamis from monodromy vectors
 #! @Arguments n d v
-DeclareGlobalFunction("CyclicTorusCoverOrigamiS", [IsPosInt, IsPosInt, IsRowVector]);
+DeclareGlobalFunction("CyclicTorusCoverOrigamiS");
 
 #! @Arguments n d v
 #! @Returns a cyclic torus cover origami whose monodromy vector with respect to the basis $S$ (respectively $L$) is $v$.
@@ -78,7 +78,7 @@ DeclareGlobalFunction("CyclicTorusCoverOrigamiS", [IsPosInt, IsPosInt, IsRowVect
 #! gap> CyclicTorusCoverOrigamiS(2,2,[1,0,1,0,0]);
 #! Origami((1,2,5,6)(3,4)(7,8), (1,3,5,7)(2,4)(6,8), 8)
 #! @EndExampleSession
-DeclareGlobalFunction("CyclicTorusCoverOrigamiL", [IsPosInt, IsPosInt, IsRowVector]);
+DeclareGlobalFunction("CyclicTorusCoverOrigamiL");
 
 #! @EndGroup
 
@@ -97,7 +97,7 @@ DeclareGlobalFunction("CyclicTorusCoverOrigamiL", [IsPosInt, IsPosInt, IsRowVect
 #!   [   0,   0,   1,   0,  -1 ],
 #!   [   0,   1,   0,   0,   1 ] ]
 #! @EndExampleSession
-DeclareGlobalFunction("BaseChangeLToS", [IsPosInt]);
+DeclareGlobalFunction("BaseChangeLToS");
 
 #! @Arguments n
 #! @Returns the group of translations (as matrices) acting on monodromy vectors with respect to $L$.
@@ -107,7 +107,7 @@ DeclareGlobalFunction("BaseChangeLToS", [IsPosInt]);
 #! gap> Order(TranslationGroupOnHomologyOfTn(3));
 #! 9
 #! @EndExampleSession
-DeclareGlobalFunction("TranslationGroupOnHomologyOfTn", [IsPosInt]);
+DeclareGlobalFunction("TranslationGroupOnHomologyOfTn");
 
 #! @Arguments n
 #! @Returns a matrix representing the action of the generator $T$ of $\mathrm{Sl}_2(\mathbb{Z})$ on the homology of $T_n$ with respect to $L$.
@@ -120,7 +120,7 @@ DeclareGlobalFunction("TranslationGroupOnHomologyOfTn", [IsPosInt]);
 #!   [   0,   0,   0,   1,  -1 ],
 #!   [   0,  -1,   0,   0,  -1 ] ]
 #! @EndExampleSession
-DeclareGlobalFunction("ActionOfTOnHomologyOfTn", [IsPosInt]);
+DeclareGlobalFunction("ActionOfTOnHomologyOfTn");
 
 #! @Arguments n
 #! @Returns a matrix representing the action of the generator $S$ of $\mathrm{Sl}_2(\mathbb{Z})$ on the homology of $T_n$ with respect to $L$.
@@ -133,7 +133,7 @@ DeclareGlobalFunction("ActionOfTOnHomologyOfTn", [IsPosInt]);
 #!   [   0,   0,   0,   0,   1 ],
 #!   [  -1,   0,   0,   1,   0 ] ]
 #! @EndExampleSession
-DeclareGlobalFunction("ActionOfSOnHomologyOfTn", [IsPosInt]);
+DeclareGlobalFunction("ActionOfSOnHomologyOfTn");
 
 #! @Arguments n A
 #! @Returns a matrix representing the action of $A \in \mathrm{Sl}_2(\mathbb{Z})$ on the homology of $T_n$ with respect to $L$.
@@ -148,4 +148,4 @@ DeclareGlobalFunction("ActionOfSOnHomologyOfTn", [IsPosInt]);
 #!   [   0,  -1,   0,   0,  -1 ],
 #!   [  -1,  -1,   0,   1,  -1 ] ]
 #! @EndExampleSession
-DeclareGlobalFunction("ActionOfMatrixOnHomologyOfTn", [IsPosInt, IsMatrix]);
+DeclareGlobalFunction("ActionOfMatrixOnHomologyOfTn");

--- a/lib/origami.gi
+++ b/lib/origami.gi
@@ -296,7 +296,7 @@ InstallOtherMethod(SumOfLyapunovExponents, [IsNormalStoredOrigami], function(O)
 	return sum;
 end);
 
-InstallGlobalFunction(NormalformConjugators, [IsOrigami],function(origami)
+InstallGlobalFunction(NormalformConjugators, function(origami)
 	local n, i, j, L, Q, seen, numSeen, v, wx, wy, G, minimalCycleLengths,
 				minimizeCycleLengths, cycleLengths, m, l, x, y;
 	x := HorizontalPerm(origami);
@@ -345,7 +345,7 @@ InstallGlobalFunction(NormalformConjugators, [IsOrigami],function(origami)
 	return G;
 end);
 
-InstallGlobalFunction(PointReflectionsOfOrigami, [IsOrigami],	function(origami)
+InstallGlobalFunction(PointReflectionsOfOrigami, function(origami)
  local origami_1, G, G_1, O, O_1, list, i, j;
 	if not VeechGroupIsEven(origami) then # testing if -1 is in the VeechGroup
 			Error("VeechGroup must contain -1");
@@ -366,7 +366,7 @@ InstallGlobalFunction(PointReflectionsOfOrigami, [IsOrigami],	function(origami)
 end);
 
 
-InstallGlobalFunction(AutomorphismsOfOrigami, [IsOrigami], function(O)
+InstallGlobalFunction(AutomorphismsOfOrigami, function(O)
 	return [[TranslationsOfOrigami(O),1], [PointReflectionsOfOrigami(O),-1]];
 end);
 


### PR DESCRIPTION
The function DeclareGlobalFunction only takes a single argument,
while InstallGlobalFunction takes two.

Older GAP versions however allowed passing in additional arguments,
which were ignored. This is changing in future GAP releases.
