### PR TITLE
Fixes for init.g and read.g

### DIFF
--- a/init.g
+++ b/init.g
@@ -1,10 +1,6 @@
 LoadPackage("orb");
 LoadPackage("ModularGroup");
 
-if not IsBound(conjugacyClassesOfx) then
-	conjugacyClassesOfx := [];
-fi;
-
 ReadPackage("Origami/lib/origami.gd");
 ReadPackage("Origami/lib/action.gd");
 ReadPackage("Origami/lib/canonical.gd");

--- a/init.g
+++ b/init.g
@@ -1,6 +1,3 @@
-LoadPackage("orb");
-LoadPackage("ModularGroup");
-
 ReadPackage("Origami", "lib/origami.gd");
 ReadPackage("Origami", "lib/action.gd");
 ReadPackage("Origami", "lib/canonical.gd");

--- a/init.g
+++ b/init.g
@@ -1,21 +1,21 @@
 LoadPackage("orb");
 LoadPackage("ModularGroup");
 
-ReadPackage("Origami/lib/origami.gd");
-ReadPackage("Origami/lib/action.gd");
-ReadPackage("Origami/lib/canonical.gd");
-ReadPackage("Origami/lib/hash.gd");
-ReadPackage("Origami/lib/origami-list.gd");
-ReadPackage("Origami/lib/sage-methods.gd");
-ReadPackage("Origami/lib/deckGroup.gd");
-ReadPackage("Origami/lib/normalorigami.gd");
-ReadPackage("Origami/lib/cyclic-torus-covers.gd");
-ReadPackage("Origami/lib/homology.gd");
-ReadPackage("Origami/lib/special_origamis.gd");
-ReadPackage("Origami/lib/homologyaction.gd");
+ReadPackage("Origami", "lib/origami.gd");
+ReadPackage("Origami", "lib/action.gd");
+ReadPackage("Origami", "lib/canonical.gd");
+ReadPackage("Origami", "lib/hash.gd");
+ReadPackage("Origami", "lib/origami-list.gd");
+ReadPackage("Origami", "lib/sage-methods.gd");
+ReadPackage("Origami", "lib/deckGroup.gd");
+ReadPackage("Origami", "lib/normalorigami.gd");
+ReadPackage("Origami", "lib/cyclic-torus-covers.gd");
+ReadPackage("Origami", "lib/homology.gd");
+ReadPackage("Origami", "lib/special_origamis.gd");
+ReadPackage("Origami", "lib/homologyaction.gd");
 
 if TestPackageAvailability("ArangoDBInterface", "2018.12.09") = fail then
   Info(InfoWarning, 1, "The package 'ArangoDBInterface' is currently not installed. Without this package, the origami database is not available.");
 else
-  ReadPackage("Origami/lib/db.gd");
+  ReadPackage("Origami", "lib/db.gd");
 fi;

--- a/read.g
+++ b/read.g
@@ -1,24 +1,24 @@
-ReadPackage("Origami/lib/origami.gi");
-ReadPackage("Origami/lib/action.gi");
-ReadPackage("Origami/lib/canonical.gi");
-ReadPackage("Origami/lib/hash.gi");
-ReadPackage("Origami/lib/origami-list.gi");
-ReadPackage("Origami/lib/deckGroup.gi");
-ReadPackage("Origami/lib/normalorigami.gi");
-ReadPackage("Origami/lib/sage-methods.gi");
-ReadPackage("Origami/lib/actions_on_tn_covers.gi");
-ReadPackage("Origami/lib/cyclic-torus-covers.gi");
-ReadPackage("Origami/lib/search-for-cyclic-torus-origamis-with-veech-group.gi");
-ReadPackage("Origami/lib/homology.gi");
-ReadPackage("Origami/lib/special_origamis.gi");
-ReadPackage("Origami/lib/homologyaction.gi");
+ReadPackage("Origami", "lib/origami.gi");
+ReadPackage("Origami", "lib/action.gi");
+ReadPackage("Origami", "lib/canonical.gi");
+ReadPackage("Origami", "lib/hash.gi");
+ReadPackage("Origami", "lib/origami-list.gi");
+ReadPackage("Origami", "lib/deckGroup.gi");
+ReadPackage("Origami", "lib/normalorigami.gi");
+ReadPackage("Origami", "lib/sage-methods.gi");
+ReadPackage("Origami", "lib/actions_on_tn_covers.gi");
+ReadPackage("Origami", "lib/cyclic-torus-covers.gi");
+ReadPackage("Origami", "lib/search-for-cyclic-torus-origamis-with-veech-group.gi");
+ReadPackage("Origami", "lib/homology.gi");
+ReadPackage("Origami", "lib/special_origamis.gi");
+ReadPackage("Origami", "lib/homologyaction.gi");
 
 if TestPackageAvailability("ArangoDBInterface", "2018.12.09") = fail then
   Info(InfoWarning, 1, "The package 'ArangoDBInterface' is currently not installed. Without this package, the origami database is not available.");
 else
-  ReadPackage("Origami/lib/db.gi");
+  ReadPackage("Origami", "lib/db.gi");
 fi;
 
 if TestPackageAvailability("IO", "4.5.1") <> fail then
-  ReadPackage("Origami/lib/io.g");
+  ReadPackage("Origami", "lib/io.g");
 fi;


### PR DESCRIPTION
- Remove unused conjugacyClassesOfx
- Don't use deprecated 1-arg ReadPackage
- Don't use LoadPackage inside the package
