### PR TITLE
doc: derive version & release date from package metadata

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -16,12 +16,6 @@ SetPackageInfo( rec(
 		LongTitle := ~.Subtitle,
 ),
 
-##  <#GAPDoc Label="PKGVERSIONDATA">
-##  <!ENTITY VERSION "2.0.1">
-##  <!ENTITY RELEASEDATE "09 July 2024">
-##  <!ENTITY RELEASEYEAR "2024">
-##  <#/GAPDoc>
-
 Dependencies := rec(
 		GAP := "4.10",
 
@@ -184,5 +178,21 @@ BannerString := Concatenation("""
 """),
 
 TestFile := "tst/testall.g",
+
+AutoDoc := rec(
+    entities := rec(
+        VERSION := ~.Version,
+        RELEASEYEAR := ~.Date{[7..10]},
+        RELEASEDATE := function(date)
+          local day, month, year, allMonths;
+          day := Int(date{[1,2]});
+          month := Int(date{[4,5]});
+          year := Int(date{[7..10]});
+          allMonths := [ "January", "February", "March", "April", "May", "June", "July",
+                         "August", "September", "October", "November", "December"];
+          return Concatenation(String(day)," ", allMonths[month], " ", String(year));
+        end(~.Date),
+    ),
+),
 
 ) );

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!DOCTYPE Book SYSTEM "gapdoc.dtd"
-    [ <!ENTITY ModularGroup "<Package>Origami</Package>">
-      <#Include Label="PKGVERSIONDATA">
-    ] >
+<!DOCTYPE Book SYSTEM "gapdoc.dtd" [
+ <#Include SYSTEM "_entities.xml">
+]>
 
 <Book Name="Origami">
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -8,7 +8,10 @@ fi;
 
 AutoDoc(rec(
     gapdoc := rec(main := "manual.xml"),
-    scaffold := false,
+    scaffold := rec(
+        TitlePage := false,
+        MainPage := false,
+    ),
     autodoc := true,
     #extract_examples := true,
 ));


### PR DESCRIPTION
A similar patch should also be applied to ModularGroup