### PR TITLE
Don't use InstallValue for integer constants

### DIFF
--- a/lib/db.gd
+++ b/lib/db.gd
@@ -1,6 +1,5 @@
 DeclareGlobalFunction("ConnectToOrigamiDB");
 DeclareGlobalVariable("ORIGAMI_DB");
-DeclareGlobalVariable("ARANGODB_MAX_INT");
 
 DeclareOperation("InsertVeechGroupIntoDB", [IsModularSubgroup]);
 DeclareOperation("GetVeechGroupDBEntry", [IsModularSubgroup]);

--- a/lib/db.gi
+++ b/lib/db.gi
@@ -5,7 +5,7 @@ InstallGlobalFunction(ConnectToOrigamiDB, function()
     "--server.username", "origami"
   ]));
 end);
-InstallValue(ARANGODB_MAX_INT, (2-2^(-52))*2^1023);
+BindGlobal("ARANGODB_MAX_INT", (2-2^(-52))*2^1023);
 
 
 InstallMethod(InsertVeechGroupIntoDB, [IsModularSubgroup], function(VG)


### PR DESCRIPTION
Fixes a warning in GAP master.
