### PR TITLE
Suggest MathJax version of manual as default

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 	PackageDoc := rec(
 		BookName  := ~.PackageName,
 		ArchiveURLSubset := ["doc"],
-		HTMLStart := "doc/chap0.html",
+		HTMLStart := "doc/chap0_mj.html",
 		PDFFile   := "doc/manual.pdf",
 		SixFile   := "doc/manual.six",
 		LongTitle := ~.Subtitle,


### PR DESCRIPTION
This is mainly relevant for the package & GAP website, as they link to this file.
