### PR TITLE
Make SmallGrp an explicit dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -19,7 +19,7 @@ SetPackageInfo( rec(
 Dependencies := rec(
 		GAP := "4.12",
 
-		NeededOtherPackages := [["ModularGroup", "2.0.1"], ["Orb", "4.7.6"]],
+		NeededOtherPackages := [["ModularGroup", "2.0.1"], ["Orb", "4.7.6"], ["SmallGrp", "1.3"]],
 
 		ExternalConditions := []
 


### PR DESCRIPTION
Origami uses the small groups library in several places:

  - AllNormalOrigamisByDegree (lib/normalorigami.gi) and QROFromOrder
    (lib/origami.gi) enumerate all groups of a given order via
    AllSmallGroups;
  - the pickling code in lib/io.g stores IdGroup(DeckGroup(O)) and
    restores the deck group with OneSmallGroup.

Without the SmallGrp package this failed, e.g. in a GAP started with
`--bare':

    Error, Variable: 'AllSmallGroups' must have an assigned value

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
